### PR TITLE
Fix User model var  and add function to get user roles

### DIFF
--- a/classes/models/user.php
+++ b/classes/models/user.php
@@ -21,6 +21,13 @@ class User {
 	protected $ID;
 
 	/**
+	 * The user ACF fields
+	 *
+	 * @var array
+	 */
+	protected $fields = null;
+
+	/**
 	 *
 	 * @param \WP_User $object
 	 *
@@ -164,6 +171,18 @@ class User {
 		$user_email = $this->user->get( 'user_email' );
 
 		return ! empty( $user_email ) ? $user_email : false;
+	}
+
+	/**
+	 * Get Roles
+	 *
+	 * @return bool|array
+	 *
+	 * @author Romain DORR
+	 */
+	public function get_roles() {
+		$roles = $this->user->roles;
+		return ! empty( $roles ) ? $roles : false;
 	}
 
 	/**

--- a/classes/models/user.php
+++ b/classes/models/user.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace BEA\PB\Models;
 
 /**
@@ -11,51 +12,52 @@ namespace BEA\PB\Models;
 class User {
 
 	/**
-	 * @var \WP_User : the User object
+	 * The WP User object
+	 * @var \WP_User
 	 */
 	public $user;
 
 	/**
-	 * @var int the element id
+	 * The user id
+	 * @var int
 	 */
 	protected $ID;
 
 	/**
-	 * The user ACF fields
-	 *
+	 * All ACF fields
 	 * @var array
 	 */
-	protected $fields = null;
+	protected $fields;
 
 	/**
 	 *
 	 * @param \WP_User $object
 	 *
-	 * @throws \Exception
+	 * @throws \InvalidArgumentException
 	 */
-	function __construct( \WP_User $object ) {
+	public function __construct( \WP_User $user_obj ) {
 
-		if ( ! $object->exists() ) {
-			throw new \Exception( 'User does not exist', 'user_does_not_exist' );
+		if ( ! $user_obj->exists() ) {
+			throw new \InvalidArgumentException( 'User does not exist' );
 		}
 
-		$this->user = $object;
-		$this->ID   = $object->ID;
-
-		return;
+		$this->user = $user_obj;
+		$this->ID   = $user_obj->ID;
 	}
 
 	/**
 	 * Create user
 	 *
-	 * @param array  $args
+	 * @param array       $args
+	 * @param string|null $user_email
+	 *
+	 * @return \WP_Error|User
+	 *
 	 * @deprecated 2.1.3 $user_email Use first argument as array.
 	 *
-	 * @return false or user model
-	 *
-	 * @author Alexandre Sadowski|Romain DORR
+	 * @author     Alexandre Sadowski|Romain DORR
 	 */
-	public static function create( $args, $user_email = null ) {
+	public static function create( array $args, $user_email = null ) {
 		if ( null !== $user_email ) {
 			_deprecated_argument( __FUNCTION__, '2.1.3', esc_html__( 'Use first argument as array', 'bea-plugin-boilerplate' ) );
 			$args = [
@@ -63,30 +65,31 @@ class User {
 				'user_email' => $user_email,
 			];
 		}
-		return self::_create( $args );
+
+		return self::create_user( $args );
 	}
 
 	/**
 	 * User creation method
 	 *
-	 * @param array  $args
+	 * @param array $args
 	 *
-	 * @return User|bool
+	 * @return User|\WP_Error
 	 *
 	 * @author Alexandre Sadowski|Romain DORR
 	 */
-	protected static function _create( $args ) {
+	protected static function create_user( array $args ) {
 		$random_password = wp_generate_password( 12, false );
 
 		$defaults = [
-		    'user_pass' => $random_password,
+			'user_pass' => $random_password,
 		];
 		$userdata = wp_parse_args( $args, $defaults );
 
 		$user_id = wp_insert_user( $userdata );
 
 		if ( is_wp_error( $user_id ) ) {
-			return false;
+			return $user_id;
 		}
 
 		return new self( new \WP_User( $user_id ) );
@@ -95,15 +98,14 @@ class User {
 	/**
 	 * @return int
 	 */
-	public function get_ID() {
+	public function get_id(): int {
 		return $this->ID;
 	}
-
 
 	/**
 	 * @return \WP_User
 	 */
-	public function get_user() {
+	public function get_user(): \WP_User {
 		return $this->user;
 	}
 
@@ -135,8 +137,8 @@ class User {
 	 * }
 	 * @return false|string `<img>` tag for the user's avatar. False on failure.
 	 */
-	public function get_avatar( $size = 96, $default = '', $alt = '', $args = null ) {
-		return get_avatar( $this->get_ID(), $size, $default, $alt, $args );
+	public function get_avatar( $size = 96, $default_url = '', $alt = '', $args = null ) {
+		return get_avatar( $this->get_id(), $size, $default_url, $alt, $args );
 	}
 
 	/**
@@ -161,7 +163,6 @@ class User {
 		return ! empty( $last_name ) ? $last_name : false;
 	}
 
-
 	/**
 	 * Get email of user
 	 *
@@ -174,54 +175,39 @@ class User {
 	}
 
 	/**
-	 * Get Roles
-	 *
-	 * @return bool|array
-	 *
-	 * @author Romain DORR
-	 */
-	public function get_roles() {
-		$roles = $this->user->roles;
-		return ! empty( $roles ) ? $roles : false;
-	}
-
-	/**
 	 * Check capability of user
 	 *
 	 * @param string $capability
 	 *
 	 * @return mixed
 	 */
-	public function has_cap( $capability ) {
+	public function has_cap( string $capability ) {
 
 		$args = array_slice( func_get_args(), 1 );
-		$args = array_merge( array( $capability ), $args );
+		$args = array_merge( [ $capability ], $args );
 
-		return call_user_func_array( array( $this->get_user(), 'has_cap' ), $args );
+		return call_user_func_array( [ $this->get_user(), 'has_cap' ], $args );
 	}
 
 	/**
 	 * Provided the meta value of meta key given
 	 *
 	 * @param string $key
-	 * @param bool $format : format or not, specific to ACF
+	 * @param bool   $format : format or not, specific to ACF
 	 *
-	 * @return bool
+	 * @return array|false|mixed
 	 */
-	public function get_meta( $key, $format = true ) {
+	public function get_meta( string $key, $format = true ) {
 		if ( empty( $key ) ) {
 			return false;
 		}
 
-		// Get all ACF fields
-		$fields = $this->get_fields();
-
 		// Check ACF
-		if ( ! isset( $fields[ $key ] ) || ! function_exists( 'get_field' ) ) {
-			return $this->user->{$key};
+		if ( ! function_exists( 'get_field' ) ) {
+			return get_user_meta( $this->get_id(), $key, true );
 		}
 
-		return get_field( $fields[ $key ], 'user_' . $this->get_ID(), $format );
+		return get_field( $key, $this->user, $format );
 	}
 
 	/**
@@ -232,37 +218,33 @@ class User {
 	 *
 	 * @return bool|int
 	 */
-	public function update_meta( $key, $value = '' ) {
+	public function update_meta( string $key, $value = '' ) {
 		if ( empty( $key ) ) {
 			return false;
 		}
 
 		// Check if model implement a method for this particular meta
 		if ( method_exists( $this, 'update_meta_' . $key ) ) {
-			return call_user_func( array( $this, 'update_meta_' . $key ), $value );
+			return $this->{'update_meta_' . $key}( $value );
 		}
 
-		return $this->_update_meta( $key, $value );
+		return $this->update_user_meta( $key, $value );
 	}
 
 	/**
 	 * Really update the value
 	 *
-	 * @param        $key
+	 * @param string $key
 	 * @param string $value
 	 *
 	 * @return bool|int
 	 */
-	protected function _update_meta( $key, $value = '' ) {
+	protected function update_user_meta( string $key, $value = '' ) {
 		if ( ! function_exists( 'update_field' ) ) {
-			return update_user_meta( $this->get_ID(), $key, $value );
+			return update_user_meta( $this->get_id(), $key, $value );
 		}
 
-		// Get the fields and use the ACF ones
-		$fields = $this->get_fields();
-		$key    = isset( $fields[ $key ] ) ? $fields[ $key ] : $key;
-
-		return update_field( $key, $value, 'user_' . $this->get_ID() );
+		return update_field( $key, $value, 'user_' . $this->get_id() );
 	}
 
 	/**
@@ -270,22 +252,23 @@ class User {
 	 *
 	 * @return array
 	 */
-	protected function get_fields() {
+	protected function get_fields(): array {
 		if ( ! is_null( $this->fields ) ) {
 			return $this->fields;
 		}
 
-		$groups = acf_get_field_groups( array( 'user_role' => 'all' ) );
+		$groups = acf_get_field_groups( [ 'user_role' => 'all' ] );
 
 		if ( empty( $groups ) ) {
-			return array();
+			return [];
 		}
-		$fields = array();
+		$fields = [];
 		foreach ( $groups as $group ) {
 			$fields += acf_get_fields( $group );
 		}
 
-		$acf_fields = array();
+		$acf_fields = [];
+		/** @psalm-suppress PossiblyInvalidIterator */
 		foreach ( $fields as $field ) {
 			$acf_fields[ $field['name'] ] = $field['key'];
 		}
@@ -304,7 +287,7 @@ class User {
 	 * @return bool|\WP_Error
 	 */
 	public function delete( $reassign = null ) {
-		return (bool) wp_delete_user( $this->get_ID(), $reassign );
+		return wp_delete_user( $this->get_id(), $reassign );
 	}
 
 	/**
@@ -314,9 +297,21 @@ class User {
 	 *
 	 * @return string|bool
 	 */
-	public function get_permalink( $args = array() ) {
-		$url = get_the_author_meta( 'url', $this->get_ID() );
+	public function get_permalink( $args = [] ) {
+		$url = get_the_author_meta( 'url', $this->get_id() );
 
 		return ( ! $url ) ? add_query_arg( $args, $url ) : false;
+	}
+
+	/**
+	 * Get Roles
+	 *
+	 * @return bool|array
+	 *
+	 * @author Romain DORR
+	 */
+	public function get_roles() {
+		$roles = $this->user->roles;
+		return ! empty( $roles ) ? $roles : false;
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `User` model public method signatures/return types (e.g., `get_ID()` -> `get_id()`, `create()` now returns `WP_Error`) and alters ACF meta read/write behavior, which can break existing callers or change stored/retrieved values.
> 
> **Overview**
> **Refactors the `User` model API and error handling.** The constructor now throws `InvalidArgumentException` for nonexistent users, `create()` is type-hinted and returns `WP_Error` on failure (instead of `false`), and several methods were renamed/typed (notably `get_ID()` -> `get_id()`).
> 
> **Adjusts user meta access to better align with WordPress/ACF and adds role access.** `get_meta()`/`update_meta()` now fall back to `get_user_meta()`/`update_user_meta()` when ACF isn’t available and use `get_field()`/`update_field()` directly with the user object/key, and a new `get_roles()` helper exposes the user’s roles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e2b2d137aceb860ae315e76d367f979d6e27a0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->