### PR TITLE
remove get fields, cleanup code

### DIFF
--- a/classes/Models/Model.php
+++ b/classes/Models/Model.php
@@ -50,7 +50,6 @@ abstract class Model {
 	 * @throws \Exception
 	 */
 	public function __construct( \WP_Post $post_obj ) {
-
 		if ( $post_obj->post_type !== $this->post_type ) {
 			throw new \InvalidArgumentException( sprintf( '%s post type does not match model post type %s', esc_html( $post_obj->post_type ), esc_html( $this->post_type ) ) );
 		}
@@ -137,16 +136,10 @@ abstract class Model {
 			return false;
 		}
 
-		// Get all ACF fields
-		$fields = $this->get_fields();
-
 		// Check ACF
-		if ( ! function_exists( '\get_field' ) || ( ! in_array( $key, $fields, true ) && ! isset( $fields[ $key ] ) ) ) {
-			return $this->wp_object->{$key};
+		if ( ! function_exists( '\get_field' ) ) {
+			return get_post_meta( $this->get_id(), $key, true );
 		}
-
-		// On ACF given key
-		$key = in_array( $key, $fields, true ) ? $key : $fields[ $key ];
 
 		return \get_field( $key, $this->get_id(), $format );
 	}
@@ -176,18 +169,15 @@ abstract class Model {
 	 * Really update the value
 	 *
 	 * @param string $key
-	 * @param string $value
+	 * @param mixed $value
 	 *
 	 * @return bool|int
 	 */
 	protected function update_content_meta( string $key, $value = '' ) {
+		// Check ACF
 		if ( ! function_exists( '\update_field' ) ) {
 			return update_post_meta( $this->get_id(), $key, $value );
 		}
-
-		// Get the fields and use the ACF ones
-		$fields = $this->get_fields();
-		$key    = isset( $fields[ $key ] ) ? $fields[ $key ] : $key;
 
 		return \update_field( $key, $value, $this->get_id() );
 	}

--- a/classes/Models/User.php
+++ b/classes/Models/User.php
@@ -202,15 +202,12 @@ class User {
 			return false;
 		}
 
-		// Get all ACF fields
-		$fields = $this->get_fields();
-
 		// Check ACF
-		if ( ! isset( $fields[ $key ] ) || ! function_exists( 'get_field' ) ) {
-			return $this->user->{$key};
+		if ( ! function_exists( 'get_field' ) ) {
+			return get_user_meta( $this->get_id(), $key, true );
 		}
 
-		return get_field( $fields[ $key ], 'user_' . $this->get_id(), $format );
+		return get_field( $key, 'user_' . $this->get_id(), $format );
 	}
 
 	/**
@@ -246,10 +243,6 @@ class User {
 		if ( ! function_exists( 'update_field' ) ) {
 			return update_user_meta( $this->get_id(), $key, $value );
 		}
-
-		// Get the fields and use the ACF ones
-		$fields = $this->get_fields();
-		$key    = $fields[ $key ] ?? $key;
 
 		return update_field( $key, $value, 'user_' . $this->get_id() );
 	}

--- a/classes/Models/User.php
+++ b/classes/Models/User.php
@@ -207,7 +207,7 @@ class User {
 			return get_user_meta( $this->get_id(), $key, true );
 		}
 
-		return get_field( $key, 'user_' . $this->get_id(), $format );
+		return get_field( $key, $this->user, $format );
 	}
 
 	/**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Streamlines Model and User meta get/update to use direct keys with ACF (or WP meta fallback), removing reliance on ACF fields mapping.
> 
> - **Models**:
>   - **`classes/Models/Model.php`**:
>     - `get_meta`: use direct ACF `get_field($key, $id, $format)`; fallback to `get_post_meta()` when ACF unavailable.
>     - `update_content_meta`: use direct ACF `update_field($key, $value, $id)`; fallback to `update_post_meta()` when ACF unavailable. Param `$value` loosened to `mixed`.
>     - Removed use of `get_fields()` for ACF name↔key mapping in meta access.
>   - **`classes/Models/User.php`**:
>     - `get_meta`: use direct ACF `get_field($key, $this->user, $format)`; fallback to `get_user_meta()` when ACF unavailable.
>     - `update_user_meta`: use direct ACF `update_field($key, $value, 'user_'.$id)`; fallback to `update_user_meta()`.
>     - Removed `get_fields()` mapping from meta get/update paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd0b2ffa5e495b3dec3b4ed8b32e3fc26ad15249. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->